### PR TITLE
refactor: Clean up InputTodo component by removing unused refs and si…

### DIFF
--- a/src/components/todos/InputTodo.tsx
+++ b/src/components/todos/InputTodo.tsx
@@ -1,40 +1,32 @@
 import { useSetAtom } from 'jotai'
-import React, { useRef } from 'react'
 import { SubmitErrorHandler, SubmitHandler, useForm } from 'react-hook-form'
 import { TodoForm } from './Models'
 import { addTodoListAtom } from './State'
 
 const InputTodo =() => {
   const addTodoList = useSetAtom(addTodoListAtom)
-  const contentRef = useRef<HTMLInputElement>(null);
   const {
     register,
     handleSubmit,
+    reset,
     formState: { errors },
   } = useForm<TodoForm>();
 
   const isValid: SubmitHandler<TodoForm> = (data: TodoForm) => {
     console.log(data)
 
-    if (contentRef.current) {
-      contentRef.current.value = ''
-    }
+    reset();
     addTodoList(data.content)
   };
 
   const isInValid: SubmitErrorHandler<TodoForm> = (erros: any) => {
-    console.log('errors: ' + JSON.stringify(erros.content.message));
+    console.log('errors: ' + JSON.stringify(erros.content.message))
   };
-
-  const { ref, ...rest } = register('content', { required: "contentを入力してください" });
 
   return (
     <form onSubmit={handleSubmit(isValid, isInValid)} data-testid="form">
 
-      <input {...rest} name="content" placeholder="Type ..." ref={(e) => {
-        ref(e)
-        contentRef.current = e
-      }} />
+      <input {...register('content', { required: "contentを入力してください" })} name="content" placeholder="Type ..."  />
 
       {errors.content && (
         <div

--- a/src/components/todos/InputTodo.tsx
+++ b/src/components/todos/InputTodo.tsx
@@ -19,8 +19,8 @@ const InputTodo =() => {
     addTodoList(data.content)
   };
 
-  const isInValid: SubmitErrorHandler<TodoForm> = (erros: any) => {
-    console.log('errors: ' + JSON.stringify(erros.content.message))
+  const isInValid: SubmitErrorHandler<TodoForm> = (errors: any) => {
+    console.log('errors: ' + JSON.stringify(errors.content.message))
   };
 
   return (


### PR DESCRIPTION
This pull request refactors the `InputTodo` component in `src/components/todos/InputTodo.tsx` to simplify the form handling logic by removing unnecessary code and improving readability. The most notable changes include removing the use of `useRef` for input management, streamlining the `register` usage from `react-hook-form`, and replacing manual input reset logic with the `reset` method.

### Form handling simplifications:
* Removed the `useRef` hook and its associated logic for managing the input field, relying solely on `react-hook-form` for input handling. (`[src/components/todos/InputTodo.tsxL2-R29](diffhunk://#diff-5807ba99a7f03f421ed8a9e99a72ebb388220da4ca4d5c983679e42fb9909ef4L2-R29)`)
* Simplified the `register` usage by directly applying it to the input field, removing the need for destructuring and manual reference assignment. (`[src/components/todos/InputTodo.tsxL2-R29](diffhunk://#diff-5807ba99a7f03f421ed8a9e99a72ebb388220da4ca4d5c983679e42fb9909ef4L2-R29)`)
* Replaced the manual input reset logic with the `reset` method provided by `react-hook-form`, ensuring a cleaner and more idiomatic approach to resetting the form. (`[src/components/todos/InputTodo.tsxL2-R29](diffhunk://#diff-5807ba99a7f03f421ed8a9e99a72ebb388220da4ca4d5c983679e42fb9909ef4L2-R29)`)…mplifying form handling